### PR TITLE
Set "Toggle Team DPS/Boss Meter" initial state to false

### DIFF
--- a/DPSExtremeUI.cs
+++ b/DPSExtremeUI.cs
@@ -237,7 +237,7 @@ namespace DPSExtreme
 			combatHistoryButton.Recalculate();
 			myRootPanel.Append(combatHistoryButton);
 
-			ShowTeamDPSPanel = true;
+			ShowTeamDPSPanel = false;
 			myDisplayMode = ListDisplayMode.DamageDone;
 		}
 


### PR DESCRIPTION
Before v0.5, the UI that displays details about combats and players DPS was disabled by default, requiring a hotkey (called `Toggle Team DPS/Boss Meter`) to toggle it, but this latest update enables it automatically when the game loads.

Thanks to the recent improvements such as combat history update this UI brings some really interesting insights which I personally loved, but I see most people I play with using the mod mostly for the summarized information it provides when combats finish (events and boss fights), and the fact that the UI shows up on the screen by itself has been more of an annoyance than a utility for them.

Most people are not interested into constantly looking at real time detailed DPS information and in some cases I've seen people look through the settings just to remove it from the screen, so rather than showing up the UI for everyone I think it should only be toggled manually. Does that make sense?